### PR TITLE
Diffusion 1 PE width hang fix.

### DIFF
--- a/csl/full_implementation/compile_and_run_on_simulator.sh
+++ b/csl/full_implementation/compile_and_run_on_simulator.sh
@@ -14,8 +14,8 @@ HEIGHT=1
 # Define Cross Section lookup parameters
 NPARTICLES=5 # starting particles per PE
 NNUCLIDES=2 # this is the number of nuclides per PE in a row (e.g., total nuclides = WIDTH * NNUCLIDES)
-NGRIDPOINTS=2 # Number of gridpoints per PE (e.g., the number of gridpoints in that energy band)
-NXS=1 # Number of XS lookups. Should always be 5.
+NGRIDPOINTS=10 # Number of gridpoints per PE (e.g., the number of gridpoints in that energy band)
+NXS=5 # Number of XS lookups. Should always be 5.
 
 TILE_WIDTH=1
 TILE_HEIGHT=1

--- a/csl/full_implementation/device_code.csl
+++ b/csl/full_implementation/device_code.csl
@@ -718,6 +718,10 @@ fn start_simulation() void {
   pe_row = pe_row % height;
   pe_col = pe_col % width;
 
+  if (width == 1) {
+    enable_diffusion = false;
+  }
+
 	// prep repeated densities
   //for (@range(i16, n_nuclides)) |n| {
  // 	for (@range(i16, n_xs)) |xs| {

--- a/csl/full_implementation/host_code.py
+++ b/csl/full_implementation/host_code.py
@@ -29,8 +29,10 @@ class Particle:
 # such that particles will end up with an even distribution.
 ASSUME_PERFECT_LOAD_BALANCE = False
 
-# Not going to work correctly with stochastic interpolation
-VALIDATE_RESULTS = True
+# Note: validation not expected to work when using stochastic interpolation,
+# as this mode uses the Cerebras hardware generator, which is not
+# reproducible on the host.
+VALIDATE_RESULTS = False
 
 #####################################################################
 # I/O helper functions
@@ -503,8 +505,7 @@ else:
 # Compute python reference solution on the host
 particle_xs_expected = []
 reference_particles = []
-#if VALIDATE_RESULTS:
-if False:
+if VALIDATE_RESULTS:
     print("Computing reference solution on host...")
     particle_xs_expected = calculate_xs_reference(n_starting_particles_per_pe*width*height, n_nuclides*width, n_gridpoints_per_nuclide*height, n_xs, nuclide_energy_grids, nuclide_xs_data, densities, particle_e, width, height)
 


### PR DESCRIPTION
If only 1 PE was used in a row, the diffusion stage would hang as its network is all weird. To fix, we just disabled diffusion for this case as it is not needed anyway when only 1 PE is in the row.